### PR TITLE
Nbsp character becoming corrupt on clean

### DIFF
--- a/lib/HTML/Tidy.pm
+++ b/lib/HTML/Tidy.pm
@@ -223,7 +223,7 @@ sub parse {
     }
     my $html = join( '', @_ );
 
-    utf8::encode($html) unless utf8::is_utf8($html);
+    utf8::encode($html) if utf8::is_utf8($html);
     my ($errorblock,$newline) = _tidy_messages( $html,
                                                 $self->{config_file},
                                                 $self->{tidy_options}
@@ -309,7 +309,7 @@ sub clean {
     }
     my $text = join( '', @_ );
 
-    utf8::encode($text) unless utf8::is_utf8($text);
+    utf8::encode($text) if utf8::is_utf8($text);
     if ( defined $text ) {
         $text .= "\n";
     }

--- a/t/unicode_nbsp.t
+++ b/t/unicode_nbsp.t
@@ -1,0 +1,23 @@
+#!perl -Tw
+# unicode_nbsp.t 
+
+use warnings;
+use strict;
+
+use Test::More tests => 3;
+
+BEGIN {
+    use_ok( 'HTML::Tidy' );
+}
+
+use Encode;
+
+my $bytes_string = "\x{c2}\x{a0}"; #UTF8 nbsp
+my $perl_chars   = Encode::decode("utf8",$bytes_string); #perl chars of utf8 byte string
+
+my $expected_after_tidy = "&nbsp;\n"; # HTML::Tidy adds a \n and should convert the nbsp to an html entity
+
+my $tidy = HTML::Tidy->new({ show_body_only => 1 });
+
+is( $tidy->clean( $perl_chars ), $expected_after_tidy, "Perl chars okay");
+is( $tidy->clean( $bytes_string ), $expected_after_tidy, "Byte string okay");


### PR DESCRIPTION
Same issue as #8, raising as a separate issue as a pull request.
When passing in a UTF8 byte string containing a nbsp character, it becomes corrupted.
