### PR TITLE
Ignore tidyp version in output for clean.t

### DIFF
--- a/t/clean.t
+++ b/t/clean.t
@@ -17,22 +17,21 @@ throws_ok {
 } qr/\Q$expected_pattern\E/,
 'clean() croaks when not given a string or list of strings';
 
-is(
+like(
     $tidy->clean(''),
     _expected_empty_html(),
     '$tidy->clean("") returns empty HTML document',
 );
 
 sub _expected_empty_html {
-    return <<'ENDHTML';
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
+    return qr{<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <html>
 <head>
-<meta name="generator" content="tidyp for Linux (v1.02), see www.w3.org">
+<meta name="generator" content="[^"]+">
 <title></title>
 </head>
 <body>
 </body>
 </html>
-ENDHTML
+};
 }


### PR DESCRIPTION
This is a very simple change to stop `clean.t` being sensitive to the version of `tidyp` when checking the empy document output. It's not very pretty but I gather the whole tidyp part is due to be replaced shortly - this should fix the test failure in the meantime. :)

On my Mac, the generator content is `tidyp for Mac OS X (v1.04), see www.w3.org` - I considered trying to get it to use the version string returned from `tidyp -v` but I haven't looked through `tidyp` releases to see if that's always present. It's probably not important here, anyway. :)

This avoids the generator issue in #26. It doesn't address the Windows CR/LF issue. That could be done by converting them before the `like` check - or of course, the patch discussed in #26 would avoid both issues!